### PR TITLE
TwoGtp: Flip players in SGF files on alternate games

### DIFF
--- a/src/net/sf/gogui/tools/twogtp/TwoGtp.java
+++ b/src/net/sf/gogui/tools/twogtp/TwoGtp.java
@@ -510,18 +510,31 @@ public class TwoGtp
             }
         }
 
+        if (m_referee != null)
+            m_game.setResult(resultReferee);
+        else if (resultBlack.equals(resultWhite) && ! resultBlack.equals("?"))
+            m_game.setResult(resultBlack);
+        // If KataGo is playing, we'll trust the KataGo score.
+        else if (m_black.getLabel().toLowerCase().contains("katago"))
+            m_game.setResult(resultBlack);
+        else if (m_white.getLabel().toLowerCase().contains("katago"))
+            m_game.setResult(resultWhite);
         String nameBlack = m_black.getLabel();
         String nameWhite = m_white.getLabel();
         String blackCommand = m_black.getProgramCommand();
         String whiteCommand = m_white.getProgramCommand();
         String blackVersion = m_black.getVersion();
         String whiteVersion = m_white.getVersion();
+        if (isAlternated()) {
+          nameBlack = m_white.getLabel();
+          nameWhite = m_black.getLabel();
+          blackCommand = m_white.getProgramCommand();
+          whiteCommand = m_black.getProgramCommand();
+          blackVersion = m_white.getVersion();
+          whiteVersion = m_black.getVersion();
+        }
         m_game.setPlayer(BLACK, nameBlack);
         m_game.setPlayer(WHITE, nameWhite);
-        if (m_referee != null)
-            m_game.setResult(resultReferee);
-        else if (resultBlack.equals(resultWhite) && ! resultBlack.equals("?"))
-            m_game.setResult(resultBlack);
         String host = Platform.getHostInfo();
         StringBuilder comment = new StringBuilder();
         comment.append("Black command: ");
@@ -538,9 +551,9 @@ public class TwoGtp
             comment.append(m_openingFile);
         }
         comment.append("\nResult[Black]: ");
-        comment.append(resultBlack);
+        comment.append(isAlternated() ? resultWhite : resultBlack);
         comment.append("\nResult[White]: ");
-        comment.append(resultWhite);
+        comment.append(isAlternated() ? resultBlack : resultWhite);
         if (m_referee != null)
         {
             comment.append("\nReferee: ");


### PR DESCRIPTION
## Context

Some annoyances with parsing `gogui-twogtp` SGF files:

### Issue 1

When `gogui-twogtp -black <player1> -white <player2>` is run with the `-alternate` flag, odd-indexed games are played with `<player1>` and `<player2>` flipped. However, the contents of `PB[]` and `PW[]` are not flipped.

For example, here are the SGFs from `gogui-twogtp -black <Leela> -white <KataGo> -games 2 -alternate`, in which KataGo (playing random moves) loses both games:

`game-0.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[Leela Zero]PW[KataGo]DT[2022-10-05]
C[Black command: docker attach e6bdb46d6c657465f4fa7754ff83791de50e08776ee6b930fb3fd61da2b75954
White command: docker attach 066da9ac0f1b51bc1a5ad41cdc57d5c53c50c5620a408fa68b908c2e20f5b238
Black version: 0.17
White version: 1.10.0
Result[Black\]: B+211.5
Result[White\]: B+254.5
Host: b0126f247630 (AMD EPYC 7763 64-Core Processor)
Date: October 5, 2022 at 1:33:43 AM UTC]
;B[dp];W[dc];B[pp];W[jm];B[qd];W[qp];B[qq];W[rs];B[qo];W[dr]
...
```
`game-1.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[Leela Zero]PW[KataGo]DT[2022-10-05]
C[Black command: docker attach e6bdb46d6c657465f4fa7754ff83791de50e08776ee6b930fb3fd61da2b75954
White command: docker attach 066da9ac0f1b51bc1a5ad41cdc57d5c53c50c5620a408fa68b908c2e20f5b238
Black version: 0.17
White version: 1.10.0
Result[Black\]: W+321.5
Result[White\]: W+358.5
Host: b0126f247630 (AMD EPYC 7763 64-Core Processor)
Date: October 5, 2022 at 2:33:53 AM UTC]
;B[qd];W[dd];B[op];W[dp];B[oa];W[qq];B[se];W[po];B[af];W[pc]
...
```
In `game-1.sgf`, KataGo is playing as black, but `PB[]`, `PW[]`, and `C[]` do not reflect that. If `game-1.sgf` is viewed as a standalone SGF file, this is incorrect.

### Issue 2

The SGF files generally don't include `RE[]` with the final score. This makes sense because the two players may disagree about the score. For our purposes, we intend to run `gogui-twogtp` to evaluate KataGo networks and trust KataGo's scoring, so we should output KataGo scores in `RE[]`. 

## Changes

Changes to make `gogui-twogtp` SGF games better to parse:
* Flip `PB[]`, `PW[]`, and the contents of `C[]` on alternate games
* If either player is KataGo, then we'll treat KataGo's scoring as the source of truth and output the score in `RE[]`

## Testing

Ran `gogui-twogtp -black <Leela> -white <KataGo> -games 2 -alternate`. Resulting SGF files:
`game-0.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[Leela Zero]PW[KataGo]DT[2022-10-08]RE[B+127.5]
C[Black command: nc leela 80
White command: nc katago 80
Black version: 0.17
White version: 1.10.0
Result[Black\]: B+121.5
Result[White\]: B+127.5
Host: ddad770d82d0 (AMD EPYC 7763 64-Core Processor)
Date: October 8, 2022 at 6:12:08 AM UTC]
;B[dp];W[je];B[dd];W[lm];B[pd];W[pj];B[pp];W[cj];B[cn];W[oe]
...
```
`game-1.sgf`:
```
(;FF[4]CA[UTF-8]AP[gogui-twogtp:1.5.1]
KM[6.5]PB[KataGo]PW[Leela Zero]DT[2022-10-08]RE[W+225.5]
C[Black command: nc katago 80
White command: nc leela 80
Black version: 1.10.0
White version: 0.17
Result[Black\]: W+225.5
Result[White\]: W+207.5
Host: ddad770d82d0 (AMD EPYC 7763 64-Core Processor)
Date: October 8, 2022 at 6:12:17 AM UTC]
;B[kj];W[pd];B[gf];W[dd];B[nj];W[pp];B[bo];W[cp];B[jr];W[fq]
...
```
`game.dat`: (The behavior here is unchanged—the scores are all relative to the original `-black` and `-white` args) 
```
# Black: Leela Zero
# BlackCommand: nc leela 80
# BlackLabel: Leela Zero
# BlackVersion: 0.17
# Date: October 8, 2022 at 6:12:00 AM UTC
# Host: ddad770d82d0 (AMD EPYC 7763 64-Core Processor)
# Komi: 6.5
# Referee: -
# Size: 19
# White: KataGo
# WhiteCommand: nc katago 80
# WhiteLabel: KataGo
# WhiteVersion: 1.10.0
# Xml: 0
#
#GAME   RES_B   RES_W   RES_R   ALT     DUP     LEN     TIME_B  TIME_W  CPU_B   CPU_W   ERR     ERR_MSG
0       B+121.5 B+127.5 ?       0       -       337     6.9     0.2     0       0.2     0
1       B+207.5 B+225.5 ?       1       -       432     9       0.3     0       0.2     0
```